### PR TITLE
Fix error `posix_memalign was not declared in this scope` when bulding `make bench-full`

### DIFF
--- a/bench/bench.h
+++ b/bench/bench.h
@@ -2,6 +2,7 @@
 #define BENCH_H
 
 #include <string>
+#include <stdlib.h>
 
 #ifdef __APPLE__
     #define BENCH_MACH


### PR DESCRIPTION
posix_memalign is declared in stdlib.h header
http://pubs.opengroup.org/onlinepubs/007904975/functions/posix_memalign.html
