### PR TITLE
Neon support, perf improvements and fixes for warnings

### DIFF
--- a/include/vectorial/simd2f.h
+++ b/include/vectorial/simd2f.h
@@ -1,0 +1,38 @@
+/*
+  Vectorial
+  Copyright (c) 2014 Google, Inc.
+  Licensed under the terms of the two-clause BSD License (see LICENSE)
+*/
+
+#ifndef VECTORIAL_SIMD2F_H
+#define VECTORIAL_SIMD2F_H
+
+#include "vectorial/config.h"
+
+#if defined(VECTORIAL_NEON)
+    #include "simd2f_neon.h"
+#else
+    #error No implementation defined
+#endif
+
+#include "simd2f_common.h"
+
+#ifdef __cplusplus
+
+    #ifdef VECTORIAL_OSTREAM
+        #include <ostream>
+
+        vectorial_inline std::ostream& operator<<(std::ostream& os, const simd2f& v) {
+            os << "simd2f(" << simd2f_get_x(v) << ", "
+                       << simd4f_get_y(v) << ")";
+            return os;
+        }
+    #endif
+
+#endif
+
+
+
+
+#endif
+

--- a/include/vectorial/simd2f_common.h
+++ b/include/vectorial/simd2f_common.h
@@ -1,0 +1,22 @@
+/*
+  Vectorial
+  Copyright (c) 2014 Google
+  Licensed under the terms of the two-clause BSD License (see LICENSE)
+*/
+#ifndef VECTORIAL_SIMD2F_COMMON_H
+#define VECTORIAL_SIMD2F_COMMON_H
+
+vectorial_inline simd2f simd2f_length2(simd2f v) {
+    return simd2f_sqrt( simd2f_dot2(v,v) );
+}
+
+vectorial_inline simd2f simd2f_length2_squared(simd2f v) {
+    return simd2f_dot2(v,v);
+}
+
+vectorial_inline simd2f simd2f_normalize2(simd2f a) {
+    simd2f invlen = simd2f_rsqrt( simd2f_dot2(a,a) );
+    return simd2f_mul(a, invlen);
+}
+
+#endif

--- a/include/vectorial/simd2f_neon.h
+++ b/include/vectorial/simd2f_neon.h
@@ -1,0 +1,159 @@
+/*
+  Vectorial
+  Copyright (c) 2010 Mikko Lehtonen
+  Copyright (c) 2014 Google, Inc.
+  Licensed under the terms of the two-clause BSD License (see LICENSE)
+*/
+#ifndef VECTORIAL_SIMD2F_NEON_H
+#define VECTORIAL_SIMD2F_NEON_H
+
+#include <arm_neon.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+typedef float32x2_t simd2f;
+
+typedef union {
+    simd2f s ;
+    float f[2];
+} _simd2f_union;
+
+
+
+vectorial_inline simd2f simd2f_create(float x, float y) {
+    const float32_t d[2] = { x,y };
+    simd2f s = vld1_f32(d);
+    return s;
+}
+
+vectorial_inline simd2f simd2f_zero() { return vdup_n_f32(0.0f); }
+
+vectorial_inline simd2f simd2f_uload2(const float *ary) {
+    const float32_t* ary32 = (const float32_t*)ary;
+    simd2f s = vld1_f32(ary32);
+    return s;
+}
+
+vectorial_inline void simd2f_ustore2(const simd2f val, float *ary) {
+    vst1_f32( (float32_t*)ary, val);
+}
+
+vectorial_inline simd2f simd2f_splat(float v) {
+    simd2f s = vdup_n_f32(v);
+    return s;
+}
+
+vectorial_inline simd2f simd2f_splat_x(simd2f v) {
+    simd2f ret = vdup_lane_f32(v, 0);
+    return ret;
+}
+
+vectorial_inline simd2f simd2f_splat_y(simd2f v) {
+    simd2f ret = vdup_lane_f32(v, 1);
+    return ret;
+}
+
+vectorial_inline simd2f simd2f_reciprocal(simd2f v) {
+    simd2f estimate = vrecpe_f32(v);
+    estimate = vmul_f32(vrecps_f32(estimate, v), estimate);
+    estimate = vmul_f32(vrecps_f32(estimate, v), estimate);
+    return estimate;
+}
+
+vectorial_inline void simd2f_rsqrt_1iteration(const simd2f& v, simd2f& estimate) {
+    simd2f estimate2 = vmul_f32(estimate, v);
+    estimate = vmul_f32(estimate, vrsqrts_f32(estimate2, estimate));
+}
+
+vectorial_inline simd2f simd2f_rsqrt1(simd2f v) {
+    simd2f estimate = vrsqrte_f32(v);
+    simd2f_rsqrt_1iteration(v, estimate);
+    return estimate;
+}
+
+vectorial_inline simd2f simd2f_rsqrt2(simd2f v) {
+    simd2f estimate = vrsqrte_f32(v);
+    simd2f_rsqrt_1iteration(v, estimate);
+    simd2f_rsqrt_1iteration(v, estimate);
+    return estimate;
+}
+
+vectorial_inline simd2f simd2f_rsqrt3(simd2f v) {
+    simd2f estimate = vrsqrte_f32(v);
+    simd2f_rsqrt_1iteration(v, estimate);
+    simd2f_rsqrt_1iteration(v, estimate);
+    simd2f_rsqrt_1iteration(v, estimate);
+    return estimate;
+}
+
+// http://en.wikipedia.org/wiki/Fast_inverse_square_root makes the argument for
+// one iteration but two gives a signficant accuracy improvment.
+vectorial_inline simd2f simd2f_rsqrt(simd2f v) {
+    return simd2f_rsqrt2(v);
+}
+
+vectorial_inline simd2f simd2f_sqrt(simd2f v) {
+
+    return vreinterpret_f32_u32(vand_u32( vtst_u32(vreinterpret_u32_f32(v),
+                                                      vreinterpret_u32_f32(v)),
+                                            vreinterpret_u32_f32(
+                                              simd2f_reciprocal(simd2f_rsqrt(v)))
+                                          )
+                                );
+
+}
+
+// arithmetics
+
+vectorial_inline simd2f simd2f_add(simd2f lhs, simd2f rhs) {
+    simd2f ret = vadd_f32(lhs, rhs);
+    return ret;
+}
+
+vectorial_inline simd2f simd2f_sub(simd2f lhs, simd2f rhs) {
+    simd2f ret = vsub_f32(lhs, rhs);
+    return ret;
+}
+
+vectorial_inline simd2f simd2f_mul(simd2f lhs, simd2f rhs) {
+    simd2f ret = vmul_f32(lhs, rhs);
+    return ret;
+}
+
+vectorial_inline simd2f simd2f_div(simd2f lhs, simd2f rhs) {
+    simd2f recip = simd2f_reciprocal( rhs );
+    simd2f ret = vmul_f32(lhs, recip);
+    return ret;
+}
+
+vectorial_inline simd2f simd2f_madd(simd2f m1, simd2f m2, simd2f a) {
+    return vmla_f32( a, m1, m2 );
+}
+
+vectorial_inline float simd2f_get_x(simd2f s) { return vget_lane_f32(s, 0); }
+vectorial_inline float simd2f_get_y(simd2f s) { return vget_lane_f32(s, 1); }
+
+vectorial_inline simd2f simd2f_dot2(simd2f lhs, simd2f rhs) {
+    const simd2f m = simd2f_mul(lhs, rhs);
+    return vpadd_f32(m, m);
+}
+
+vectorial_inline simd2f simd2f_min(simd2f a, simd2f b) {
+    return vmin_f32( a, b );
+}
+
+vectorial_inline simd2f simd2f_max(simd2f a, simd2f b) {
+    return vmax_f32( a, b );
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif
+

--- a/include/vectorial/simd4f_common.h
+++ b/include/vectorial/simd4f_common.h
@@ -1,6 +1,7 @@
 /*
   Vectorial
   Copyright (c) 2010 Mikko Lehtonen
+  Copyright (c) 2014 Google, Inc.
   Licensed under the terms of the two-clause BSD License (see LICENSE)
 */
 #ifndef VECTORIAL_SIMD4F_COMMON_H
@@ -18,13 +19,6 @@ vectorial_inline simd4f simd4f_dot4(simd4f lhs, simd4f rhs) {
     return simd4f_sum( simd4f_mul(lhs, rhs) );
 }
 
-vectorial_inline simd4f simd4f_dot3(simd4f lhs, simd4f rhs) {
-    const simd4f m = simd4f_mul(lhs, rhs);
-    const simd4f s1 = simd4f_add(simd4f_splat_x(m), simd4f_splat_y(m));
-    const simd4f s2 = simd4f_add(s1, simd4f_splat_z(m));
-    return s2;
-}
-
 vectorial_inline simd4f simd4f_dot2(simd4f lhs, simd4f rhs) {
     const simd4f m = simd4f_mul(lhs, rhs);
     const simd4f s1 = simd4f_add(simd4f_splat_x(m), simd4f_splat_y(m));
@@ -37,7 +31,7 @@ vectorial_inline simd4f simd4f_length4(simd4f v) {
 }
 
 vectorial_inline simd4f simd4f_length3(simd4f v) {
-    return simd4f_sqrt( simd4f_dot3(v,v) );
+    return simd4f_sqrt( simd4f_splat( simd4f_dot3(v,v) ) );
 }
 
 vectorial_inline simd4f simd4f_length2(simd4f v) {
@@ -49,6 +43,10 @@ vectorial_inline simd4f simd4f_length4_squared(simd4f v) {
 }
 
 vectorial_inline simd4f simd4f_length3_squared(simd4f v) {
+    return simd4f_dot3_splat(v,v);
+}
+
+vectorial_inline float simd4f_length3_squared_scalar(simd4f v) {
     return simd4f_dot3(v,v);
 }
 
@@ -63,8 +61,8 @@ vectorial_inline simd4f simd4f_normalize4(simd4f a) {
 }
 
 vectorial_inline simd4f simd4f_normalize3(simd4f a) {
-    simd4f invlen = simd4f_rsqrt( simd4f_dot3(a,a) );
-    return simd4f_mul(a, invlen);    
+    simd4f invlen = simd4f_rsqrt( simd4f_splat( simd4f_dot3(a,a) ) );
+    return simd4f_mul(a, invlen);
 }
 
 vectorial_inline simd4f simd4f_normalize2(simd4f a) {

--- a/include/vectorial/simd4f_neon.h
+++ b/include/vectorial/simd4f_neon.h
@@ -210,8 +210,11 @@ vectorial_inline simd4f simd4f_cross3(simd4f lhs, simd4f rhs) {
     simd4f s3 = simd4f_sub(simd4f_mul(rhs_yzx, lhs), simd4f_mul(lhs_yzx, rhs));
     // Permute cross to order xyz and zero out the fourth value
     simd2f low = vget_low_f32(s3);
+    static const uint32_t mask_array[] = {
+      0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0};
+    static const int32x4_t mask = vld1q_s32((const int32_t*)mask_array);
     s3 = vcombine_f32(vext_f32(low, vget_high_f32(s3), 1), low);
-    return (simd4f)vandq_s32((int32x4_t)s3,(int32x4_t){0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF,0});
+    return (simd4f)vandq_s32((int32x4_t)s3,mask);
 }
 
 vectorial_inline simd4f simd4f_shuffle_wxyz(simd4f s) { 
@@ -275,4 +278,3 @@ vectorial_inline simd4f simd4f_max(simd4f a, simd4f b) {
 
 
 #endif
-

--- a/include/vectorial/simd4f_sse.h
+++ b/include/vectorial/simd4f_sse.h
@@ -1,12 +1,14 @@
 /*
   Vectorial
   Copyright (c) 2010 Mikko Lehtonen
+  Copyright (c) 2014 Google, Inc.
   Licensed under the terms of the two-clause BSD License (see LICENSE)
 */
 #ifndef VECTORIAL_SIMD4F_SSE_H
 #define VECTORIAL_SIMD4F_SSE_H
 
 #include <xmmintrin.h>
+#include <smmintrin.h>
 #include <string.h>  // memcpy
 
 #ifdef __cplusplus
@@ -137,8 +139,18 @@ vectorial_inline simd4f simd4f_rsqrt(simd4f v) {
     return s;
 }
 
+vectorial_inline float simd4f_get_x(simd4f s) { _simd4f_union u={s}; return u.f[0]; }
+vectorial_inline float simd4f_get_y(simd4f s) { _simd4f_union u={s}; return u.f[1]; }
+vectorial_inline float simd4f_get_z(simd4f s) { _simd4f_union u={s}; return u.f[2]; }
+vectorial_inline float simd4f_get_w(simd4f s) { _simd4f_union u={s}; return u.f[3]; }
 
+vectorial_inline simd4f simd4f_dot3_splat(simd4f lhs,simd4f rhs) {
+    return _mm_dp_ps(lhs, rhs, 0x71);
+}
 
+vectorial_inline float simd4f_dot3(simd4f lhs,simd4f rhs) {
+    return simd4f_get_x(simd4f_dot3_splat(lhs, rhs));
+}
 
 vectorial_inline simd4f simd4f_cross3(simd4f lhs, simd4f rhs) {
     
@@ -151,14 +163,6 @@ vectorial_inline simd4f simd4f_cross3(simd4f lhs, simd4f rhs) {
     return _mm_sub_ps(_mm_mul_ps(lyzx, rzxy), _mm_mul_ps(lzxy, ryzx));
 
 }
-
-
-
-vectorial_inline float simd4f_get_x(simd4f s) { _simd4f_union u={s}; return u.f[0]; }
-vectorial_inline float simd4f_get_y(simd4f s) { _simd4f_union u={s}; return u.f[1]; }
-vectorial_inline float simd4f_get_z(simd4f s) { _simd4f_union u={s}; return u.f[2]; }
-vectorial_inline float simd4f_get_w(simd4f s) { _simd4f_union u={s}; return u.f[3]; }
-
 
 vectorial_inline simd4f simd4f_shuffle_wxyz(simd4f s) { return _mm_shuffle_ps(s,s, _MM_SHUFFLE(2,1,0,3) ); }
 vectorial_inline simd4f simd4f_shuffle_zwxy(simd4f s) { return _mm_shuffle_ps(s,s, _MM_SHUFFLE(1,0,3,2) ); }

--- a/include/vectorial/simd4x4f.h
+++ b/include/vectorial/simd4x4f.h
@@ -1,6 +1,7 @@
 /*
   Vectorial
   Copyright (c) 2010 Mikko Lehtonen
+  Copyright (c) 2014 Google, Inc.
   Licensed under the terms of the two-clause BSD License (see LICENSE)
 */
 #ifndef VECTORIAL_SIMD4X4F_H
@@ -211,9 +212,9 @@ vectorial_inline void simd4x4f_lookat(simd4x4f *m, simd4f eye, simd4f center, si
 
     zaxis = simd4f_sub( simd4f_zero(), zaxis);
 
-    float x = -simd4f_get_x( simd4f_dot3(xaxis, eye) );
-    float y = -simd4f_get_x( simd4f_dot3(yaxis, eye) );
-    float z = -simd4f_get_x( simd4f_dot3(zaxis, eye) );
+    float x = -simd4f_dot3(xaxis, eye);
+    float y = -simd4f_dot3(yaxis, eye);
+    float z = -simd4f_dot3(zaxis, eye);
 
     m->x = xaxis;
     m->y = yaxis;
@@ -265,7 +266,7 @@ vectorial_inline void simd4x4f_axis_rotation(simd4x4f* m, float radians, simd4f 
 
 
 
-vectorial_inline void simd4x4f_add(simd4x4f* a, simd4x4f* b, simd4x4f* out) {
+vectorial_inline void simd4x4f_add(const simd4x4f* a, const simd4x4f* b, simd4x4f* out) {
     
     out->x = simd4f_add(a->x, b->x);
     out->y = simd4f_add(a->y, b->y);
@@ -274,7 +275,7 @@ vectorial_inline void simd4x4f_add(simd4x4f* a, simd4x4f* b, simd4x4f* out) {
     
 }
 
-vectorial_inline void simd4x4f_sub(simd4x4f* a, simd4x4f* b, simd4x4f* out) {
+vectorial_inline void simd4x4f_sub(const simd4x4f* a, const simd4x4f* b, simd4x4f* out) {
     
     out->x = simd4f_sub(a->x, b->x);
     out->y = simd4f_sub(a->y, b->y);
@@ -283,7 +284,7 @@ vectorial_inline void simd4x4f_sub(simd4x4f* a, simd4x4f* b, simd4x4f* out) {
     
 }
 
-vectorial_inline void simd4x4f_mul(simd4x4f* a, simd4x4f* b, simd4x4f* out) {
+vectorial_inline void simd4x4f_mul(const simd4x4f* a, const simd4x4f* b, simd4x4f* out) {
     
     out->x = simd4f_mul(a->x, b->x);
     out->y = simd4f_mul(a->y, b->y);

--- a/include/vectorial/simd4x4f.h
+++ b/include/vectorial/simd4x4f.h
@@ -302,7 +302,7 @@ vectorial_inline void simd4x4f_div(simd4x4f* a, simd4x4f* b, simd4x4f* out) {
     
 }
 
-vectorial_inline void simd4x4f_inverse(const simd4x4f* a, simd4x4f* out) {
+vectorial_inline simd4f simd4x4f_inverse(const simd4x4f* a, simd4x4f* out) {
 
     const simd4f c0 = a->x;
     const simd4f c1 = a->y;
@@ -374,9 +374,8 @@ vectorial_inline void simd4x4f_inverse(const simd4x4f* a, simd4x4f* out) {
     
     simd4x4f_transpose( &mt, out);
 
-
+    return det;
 }
-
 
 #ifdef __cplusplus
 

--- a/include/vectorial/vec3f.h
+++ b/include/vectorial/vec3f.h
@@ -1,6 +1,7 @@
 /*
   Vectorial
   Copyright (c) 2010 Mikko Lehtonen
+  Copyright (c) 2014 Google, Inc.
   Licensed under the terms of the two-clause BSD License (see LICENSE)
 */
 #ifndef VECTORIAL_VEC3F_H
@@ -142,7 +143,7 @@ namespace vectorial {
 
 
     vectorial_inline float dot(const vec3f& lhs, const vec3f& rhs) {
-        return simd4f_get_x( simd4f_dot3(lhs.value, rhs.value) );
+        return simd4f_dot3(lhs.value, rhs.value);
     }
 
     vectorial_inline vec3f cross(const vec3f& lhs, const vec3f& rhs) {


### PR DESCRIPTION
Hi, a couple of us in Google have made a few modifications to vectorial.  We hope you're able to merge the following patch series:
* Support for SSE1/2
* Fix for gcc narrowing conversion warnings
* Return of determinant from simx4x4_inverse to detect matrices that can't be inverted
* Perf improvement for dot product, cross product and vec3 store
* 2f NEON implementation

Cheers,
Stewart