### PR TITLE
also enable NEON with __ARM_NEON (fixes issue #11)

### DIFF
--- a/include/vectorial/config.h
+++ b/include/vectorial/config.h
@@ -12,7 +12,8 @@
 
         #define VECTORIAL_SSE
 
-    #elif defined(__ARM_NEON__) 
+    // __ARM_NEON is used instead of __ARM_NEON__ on armv8.
+    #elif defined(__ARM_NEON__) || defined(__ARM_NEON)
 
         #define VECTORIAL_NEON
 


### PR DESCRIPTION
here's a PR, as requested in #11. tested with android ndk toolchain in msvc 2019.

further reading:
- https://github.com/magnumripper/JohnTheRipper/issues/1998
- https://gcc.gnu.org/ml/gcc-patches/2015-01/msg02717.html